### PR TITLE
Enabling RSS

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -45,6 +45,8 @@ website:
     right:
       - text: "Blog"
         href: blog/index.qmd
+      - icon: rss
+        href: blog/index.xml
       - text: "FAQ"
         href: faq.qmd
       - icon: github

--- a/blog/index.qmd
+++ b/blog/index.qmd
@@ -10,5 +10,6 @@ listing:
   filter-ui: [title, date]
   page-size: 8
   sort: "date desc"
+  feed: true
 page-layout: full
 ---


### PR DESCRIPTION
Quarto can produce an RSS feed for people who want to follow the blog posts. Enabling the feed has no effect on the website besides making an index.xml file available for feed readers. Commit afc061af86437bc5902990ec82779c1c9a28d13f adds an icon beside "Blog" in the nav bar. That's helpful readers but not strictly necessary. 